### PR TITLE
fix: permissioned rebase (L1)

### DIFF
--- a/contracts/interfaces/ILSDai.sol
+++ b/contracts/interfaces/ILSDai.sol
@@ -52,6 +52,20 @@ interface ILSDai is IERC20 {
   event FeeRecipientSet(address indexed recipient);
 
   /**
+   * @notice Grants the REBASER_ROLE to an address.
+   * @dev This function grants the REBASER_ROLE to the specified address. Callable by the owner.
+   * @param rebaser The address to be granted the REBASER_ROLE.
+   */
+  function addRebaser(address rebaser) external;
+
+  /**
+   * @notice Revokes the REBASER_ROLE from an address.
+   * @dev This function revokes the REBASER_ROLE from the specified address. Callable by the owner.
+   * @param rebaser The address to have the REBASER_ROLE revoked.
+   */
+  function removeRebaser(address rebaser) external;
+
+  /**
    * @notice The DAI deposit cap.
    * @dev can be changed by the owner of the contract.
    */

--- a/test/LSDai.t.sol
+++ b/test/LSDai.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import {SafeMath} from '@openzeppelin/contracts/utils/math/SafeMath.sol';
-import {Strings} from '@openzeppelin/contracts/utils/Strings.sol';
+import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
-import {LSDAITestBase, MAKER_POT} from './common/LSDAITestBase.sol';
-import {LSDai} from '../contracts/LSDai.sol';
-import {IDai} from '../contracts/interfaces/IDai.sol';
+import {LSDAITestBase, MAKER_POT} from "./common/LSDAITestBase.sol";
+import {LSDai} from "../contracts/LSDai.sol";
+import {IDai} from "../contracts/interfaces/IDai.sol";
 
 address constant DAI_ADDRESS = address(0x6B175474E89094C44Da98b954EedeAC495271d0F);
 
@@ -17,10 +17,7 @@ contract LSDaiTests is LSDAITestBase {
   event Transfer(address indexed from, address indexed to, uint256 value);
   event TransferShares(address indexed from, address indexed to, uint256 sharesValue);
   event SharesBurnt(
-    address indexed account,
-    uint256 preRebaseTokenAmount,
-    uint256 postRebaseTokenAmount,
-    uint256 sharesAmount
+    address indexed account, uint256 preRebaseTokenAmount, uint256 postRebaseTokenAmount, uint256 sharesAmount
   );
 
   LSDai lsdai;
@@ -61,8 +58,8 @@ contract LSDaiTests is LSDAITestBase {
 
   function test_lsdaiIsERC20ish() public {
     // Check if the contract implements the ERC20 interface
-    assertEq(lsdai.symbol(), 'LSDAI');
-    assertEq(lsdai.name(), 'Liquid Savings DAI');
+    assertEq(lsdai.symbol(), "LSDAI");
+    assertEq(lsdai.name(), "Liquid Savings DAI");
     assertEq(lsdai.decimals(), 18);
 
     // Deposit DAI from LSD tripper
@@ -91,8 +88,7 @@ contract LSDaiTests is LSDAITestBase {
       // Check LSD Tripper balance
       assertEq(lsdai.balanceOf(lsdTripper), lsdaiTripperBalanceBeforeTransfer - balanceToTransfer);
       assertEq(
-        lsdai.sharesOf(lsdTripper),
-        lsdai.getSharesByPooledDai(lsdaiTripperBalanceBeforeTransfer - balanceToTransfer)
+        lsdai.sharesOf(lsdTripper), lsdai.getSharesByPooledDai(lsdaiTripperBalanceBeforeTransfer - balanceToTransfer)
       );
       // Check LSD Enjoyer balance
       assertEq(lsdai.balanceOf(lsdEnjoyer), balanceToTransfer);
@@ -122,13 +118,12 @@ contract LSDaiTests is LSDAITestBase {
 
     // Expected shares to burn from the LSD tripper
     uint256 expectedSharesToBurn = lsdai.getSharesByPooledDai(expectedWithdrawAmount);
-    uint256 expectedPreRebaseTokenAmount = lsdai.getPooledDaiByShares(expectedSharesToBurn);
+    // uint256 expectedPreRebaseTokenAmount = lsdai.getPooledDaiByShares(expectedSharesToBurn);
 
     uint256 expectedTotalLSDaiSharesAfterBurn = lsdai.totalShares() - expectedSharesToBurn;
 
-    uint256 expectedPostRebaseTokenAmount = expectedSharesToBurn.mul(expectedTotalLSDaiSharesAfterBurn).div(
-      expectedTotalLSDaiSharesAfterBurn
-    );
+    uint256 expectedPostRebaseTokenAmount =
+      expectedSharesToBurn.mul(expectedTotalLSDaiSharesAfterBurn).div(expectedTotalLSDaiSharesAfterBurn);
 
     // Submit withdrawal request
     vm.prank(lsdTripper);
@@ -155,14 +150,14 @@ contract LSDaiTests is LSDAITestBase {
     assert(dai.balanceOf(lsdTripper) == 0);
     assert(lsdai.balanceOf(lsdTripper) == lsdTripperInitialDeposit); // since 1:1 ratio and we're in the same block
 
-    logLSDAIMetrics(lsdai, 'at week 1');
+    logLSDAIMetrics(lsdai, "at week 1");
 
     vm.warp(block.timestamp + 52 weeks);
 
     lsdai.rebase();
-    logLSDAIMetrics(lsdai, 'at week 52');
+    logLSDAIMetrics(lsdai, "at week 52");
 
-    logLSDaiUserMetrics(lsdai, lsdTripper, 'LSD Tripper');
+    logLSDaiUserMetrics(lsdai, lsdTripper, "LSD Tripper");
     // Withdraw DAI from LSD tripper
     withdrawDAI(lsdTripper, lsdai.balanceOf(lsdTripper));
   }
@@ -173,13 +168,13 @@ contract LSDaiTests is LSDAITestBase {
     depositDAI(lsdEnjoyer, lsdEnjoyerInitialDeposit);
     depositDAI(lsdDreamer, lsdDreamerInitialDeposit);
 
-    logLSDAIMetrics(lsdai, 'at week 1');
+    logLSDAIMetrics(lsdai, "at week 1");
 
     // Warp to 52 weeks
     vm.warp(block.timestamp + 52 weeks);
     lsdai.rebase();
 
-    logLSDAIMetrics(lsdai, 'at week 52');
+    logLSDAIMetrics(lsdai, "at week 52");
 
     // Withdraw from LSD tripper
     {
@@ -199,30 +194,30 @@ contract LSDaiTests is LSDAITestBase {
       assertTrue(
         lsdaiEnjoyerBalanceAfterWithdraw >= lsdaiEnjoyerBalanceBeforeWithdraw,
         string.concat(
-          'LSD Enjoyer should have same or more LSDai after LSD tripper withdraws. ',
-          'Expected: ',
+          "LSD Enjoyer should have same or more LSDai after LSD tripper withdraws. ",
+          "Expected: ",
           Strings.toString(lsdaiEnjoyerBalanceBeforeWithdraw),
-          ' or more. Got:',
+          " or more. Got:",
           Strings.toString(lsdaiEnjoyerBalanceAfterWithdraw)
         )
       );
       assertTrue(
         lsdaiDreamerBalanceAfterWithdraw >= lsdaiDreamerBalanceBeforeWithdraw,
         string.concat(
-          'LSD Dreamer should have same or more LSDai after LSD tripper withdraws. ',
-          'Expected: ',
+          "LSD Dreamer should have same or more LSDai after LSD tripper withdraws. ",
+          "Expected: ",
           Strings.toString(lsdaiDreamerBalanceBeforeWithdraw),
-          ' or more. Got:',
+          " or more. Got:",
           Strings.toString(lsdaiDreamerBalanceAfterWithdraw)
         )
       );
       assertTrue(
         feeRecipientBalanceAfterWithdraw >= feeRecipientBalanceBeforeWithdraw,
         string.concat(
-          'LSDai Fee Recipient should have same or more LSDai after LSD tripper withdraws. ',
-          'Expected: ',
+          "LSDai Fee Recipient should have same or more LSDai after LSD tripper withdraws. ",
+          "Expected: ",
           Strings.toString(feeRecipientBalanceBeforeWithdraw),
-          ' or more. Got:',
+          " or more. Got:",
           Strings.toString(feeRecipientBalanceAfterWithdraw)
         )
       );
@@ -244,20 +239,20 @@ contract LSDaiTests is LSDAITestBase {
       assertTrue(
         lsdaiDreamerBalanceAfterWithdraw >= lsdaiDreamerBalanceBeforeWithdraw,
         string.concat(
-          'LSD Dreamer should have same or more LSDai after LSD Enjoyer withdraws. ',
-          'Expected: ',
+          "LSD Dreamer should have same or more LSDai after LSD Enjoyer withdraws. ",
+          "Expected: ",
           Strings.toString(lsdaiDreamerBalanceBeforeWithdraw),
-          ' or more. Got:',
+          " or more. Got:",
           Strings.toString(lsdaiDreamerBalanceAfterWithdraw)
         )
       );
       assertTrue(
         feeRecipientBalanceAfterWithdraw >= feeRecipientBalanceBeforeWithdraw,
         string.concat(
-          'LSDai Fee Recipient should have same or more LSDai after LSD Enjoyer withdraws. ',
-          'Expected: ',
+          "LSDai Fee Recipient should have same or more LSDai after LSD Enjoyer withdraws. ",
+          "Expected: ",
           Strings.toString(feeRecipientBalanceBeforeWithdraw),
-          ' or more. Got:',
+          " or more. Got:",
           Strings.toString(feeRecipientBalanceAfterWithdraw)
         )
       );
@@ -273,16 +268,16 @@ contract LSDaiTests is LSDAITestBase {
 
       assertTrue(
         lsdai.balanceOf(lsdai.feeRecipient()) >= feeRecipientBalanceBeforeWithdraw,
-        'LSDai Fee Recipient should have same or more LSDai after LSD Dreamer withdraws'
+        "LSDai Fee Recipient should have same or more LSDai after LSD Dreamer withdraws"
       );
     }
 
-    logLSDAIMetrics(lsdai, 'after everyone withdrew');
+    logLSDAIMetrics(lsdai, "after everyone withdrew");
   }
 
   function test_UserCannotExceedTheirBalanceOnWithdrawal() public {
     depositDAI(lsdTripper, lsdTripperInitialDeposit);
-    assertEq(lsdai.balanceOf(lsdTripper), lsdTripperInitialDeposit, 'LSD tripper should have initial deposit');
+    assertEq(lsdai.balanceOf(lsdTripper), lsdTripperInitialDeposit, "LSD tripper should have initial deposit");
     uint256 attemptToWithdrawByHacker = lsdai.balanceOf(lsdTripper) - 10 ether;
     vm.startPrank(lsdEnjoyer);
     vm.expectRevert(LSDai.LSDai__AmountExceedsBalance.selector);
@@ -293,9 +288,9 @@ contract LSDaiTests is LSDAITestBase {
     uint256 initialDeposit = dai.balanceOf(lsdTripper);
     // Deposit everything into LSDai
     depositDAI(lsdTripper, initialDeposit);
-    assertEq(dai.balanceOf(lsdTripper), 0, 'LSD tripper should have 0 DAI');
+    assertEq(dai.balanceOf(lsdTripper), 0, "LSD tripper should have 0 DAI");
     // 1:1 ratio
-    assertEq(lsdai.balanceOf(lsdTripper), initialDeposit, 'LSD tripper should have initial deposit');
+    assertEq(lsdai.balanceOf(lsdTripper), initialDeposit, "LSD tripper should have initial deposit");
 
     vm.warp(block.timestamp + 52 weeks);
     lsdai.rebase();
@@ -304,18 +299,18 @@ contract LSDaiTests is LSDAITestBase {
     vm.startPrank(lsdTripper);
     lsdai.withdraw(daiAmountToWithdraw);
 
-    emit log_named_uint('DAI balance', dai.balanceOf(lsdTripper));
-    emit log_named_uint('LSDai balance', lsdai.balanceOf(lsdTripper));
+    emit log_named_uint("DAI balance", dai.balanceOf(lsdTripper));
+    emit log_named_uint("LSDai balance", lsdai.balanceOf(lsdTripper));
   }
 
   function test_UserCanWithdrawRecievedLSDAI() public {
     uint256 initialDeposit = dai.balanceOf(lsdTripper);
     // Deposit everything into LSDai
     depositDAI(lsdTripper, initialDeposit);
-    assertEq(dai.balanceOf(lsdTripper), 0, 'LSD tripper should have 0 DAI');
+    assertEq(dai.balanceOf(lsdTripper), 0, "LSD tripper should have 0 DAI");
     // 1:1 ratio
-    assertEq(lsdai.balanceOf(lsdTripper), initialDeposit, 'LSD tripper should have initial deposit');
-    assertEq(lsdai.balanceOf(lsdEnjoyer), 0, 'LSD Enjoyer should have 0 LSDai');
+    assertEq(lsdai.balanceOf(lsdTripper), initialDeposit, "LSD tripper should have initial deposit");
+    assertEq(lsdai.balanceOf(lsdEnjoyer), 0, "LSD Enjoyer should have 0 LSDai");
 
     vm.warp(block.timestamp + 52 weeks);
     lsdai.rebase();
@@ -333,7 +328,7 @@ contract LSDaiTests is LSDAITestBase {
   function test_depositCapEnforced() public {
     // Set deposit cap to 100 DAI
     lsdai.setDepositCap(100 ether);
-    assertEq(lsdai.depositCap(), 100 ether, 'Deposit cap should be 100 DAI');
+    assertEq(lsdai.depositCap(), 100 ether, "Deposit cap should be 100 DAI");
 
     uint256 currentDepositCap = lsdai.depositCap();
     // Use the entire deposit cap by depositing the max amount
@@ -358,40 +353,40 @@ contract LSDaiTests is LSDAITestBase {
   }
 
   function test_feeRecipient() public {
-    assertEq(lsdai.feeRecipient(), address(this), 'Fee recipient should be this contract');
+    assertEq(lsdai.feeRecipient(), address(this), "Fee recipient should be this contract");
     // Set fee recipient to lsdTripper
     lsdai.setFeeRecipient(lsdTripper);
-    assertEq(lsdai.feeRecipient(), lsdTripper, 'Fee recipient should be lsdTripper');
+    assertEq(lsdai.feeRecipient(), lsdTripper, "Fee recipient should be lsdTripper");
     // Set fee recipient to lsdEnjoyer
     lsdai.setFeeRecipient(lsdEnjoyer);
-    assertEq(lsdai.feeRecipient(), lsdEnjoyer, 'Fee recipient should be lsdEnjoyer');
+    assertEq(lsdai.feeRecipient(), lsdEnjoyer, "Fee recipient should be lsdEnjoyer");
     // Set fee recipient to lsdDreamer
     lsdai.setFeeRecipient(lsdDreamer);
-    assertEq(lsdai.feeRecipient(), lsdDreamer, 'Fee recipient should be lsdDreamer');
+    assertEq(lsdai.feeRecipient(), lsdDreamer, "Fee recipient should be lsdDreamer");
   }
 
   function test_setWithdrawalFee() public {
     // Set withdrawal fee to 1%
     lsdai.setWithdrawalFee(100);
-    assertEq(lsdai.withdrawalFee(), 100, 'Withdrawal fee should be 1%');
+    assertEq(lsdai.withdrawalFee(), 100, "Withdrawal fee should be 1%");
     // Set withdrawal fee to 2%
     lsdai.setWithdrawalFee(200);
-    assertEq(lsdai.withdrawalFee(), 200, 'Withdrawal fee should be 2%');
+    assertEq(lsdai.withdrawalFee(), 200, "Withdrawal fee should be 2%");
     // Set withdrawal fee to 3%
     lsdai.setWithdrawalFee(300);
-    assertEq(lsdai.withdrawalFee(), 300, 'Withdrawal fee should be 3%');
+    assertEq(lsdai.withdrawalFee(), 300, "Withdrawal fee should be 3%");
   }
 
   function test_setInterestFee() public {
     // Set interest fee to 1%
     lsdai.setInterestFee(100);
-    assertEq(lsdai.interestFee(), 100, 'Interest fee should be 1%');
+    assertEq(lsdai.interestFee(), 100, "Interest fee should be 1%");
     // Set interest fee to 2%
     lsdai.setInterestFee(200);
-    assertEq(lsdai.interestFee(), 200, 'Interest fee should be 2%');
+    assertEq(lsdai.interestFee(), 200, "Interest fee should be 2%");
     // Set interest fee to 3%
     lsdai.setInterestFee(300);
-    assertEq(lsdai.interestFee(), 300, 'Interest fee should be 3%');
+    assertEq(lsdai.interestFee(), 300, "Interest fee should be 3%");
   }
 
   function depositDAI(address account, uint256 daiAmount) public {
@@ -400,6 +395,51 @@ contract LSDaiTests is LSDAITestBase {
     dai.approve(address(lsdai), type(uint256).max);
     lsdai.deposit({daiAmount: daiAmount, to: account});
     vm.stopPrank();
+  }
+
+  function test_ownerCanManageRebasers() public {
+    address lsdaiOwner = lsdai.owner(); // assuming `initialize` has been called, owner has
+    address testRebaser0 = address(0x66);
+
+    vm.startPrank(address(0x11));
+    vm.expectRevert(
+      "AccessControl: account 0x0000000000000000000000000000000000000011 is missing role 0x0000000000000000000000000000000000000000000000000000000000000000"
+    );
+    lsdai.addRebaser(testRebaser0);
+    vm.expectRevert(
+      "AccessControl: account 0x0000000000000000000000000000000000000011 is missing role 0x0000000000000000000000000000000000000000000000000000000000000000"
+    );
+    lsdai.removeRebaser(testRebaser0);
+    vm.stopPrank();
+
+    vm.startPrank(lsdaiOwner);
+    lsdai.addRebaser(testRebaser0);
+    assertEq(lsdai.hasRole(lsdai.REBASER_ROLE(), testRebaser0), true, "testRebaser0 should be a rebaser");
+
+    lsdai.removeRebaser(testRebaser0);
+    assertEq(lsdai.hasRole(lsdai.REBASER_ROLE(), testRebaser0), false, "testRebaser0 should not be a rebaser");
+    vm.stopPrank();
+  }
+
+  function test_rebasersCanRebase() public {
+    address testRebaser0 = address(0x66);
+
+    vm.expectRevert(LSDai.LSDai__NotRebaser.selector);
+    vm.prank(testRebaser0);
+    lsdai.rebase();
+
+    // Add
+    lsdai.grantRole(lsdai.REBASER_ROLE(), testRebaser0);
+    // lsdai.addRebaser(testRebaser0);
+    assertEq(lsdai.hasRole(lsdai.REBASER_ROLE(), testRebaser0), true, "testRebaser0 should be a rebaser");
+
+    // Should not revert
+    vm.prank(testRebaser0);
+    lsdai.rebase();
+
+    // Remove
+    lsdai.removeRebaser(testRebaser0);
+    assertEq(lsdai.hasRole(lsdai.REBASER_ROLE(), testRebaser0), false, "testRebaser0 should not be a rebaser");
   }
 
   function withdrawDAI(address account, uint256 daiAmount) public {

--- a/test/common/LSDAITestBase.sol
+++ b/test/common/LSDAITestBase.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import {Test} from 'forge-std/Test.sol';
+import {Test} from "forge-std/Test.sol";
 
-import {IDai} from '../../contracts/interfaces/IDai.sol';
-import {LSDai} from '../../contracts/LSDai.sol';
+import {IDai} from "../../contracts/interfaces/IDai.sol";
+import {LSDai} from "../../contracts/LSDai.sol";
 
 address constant DAI_ADDRESS = address(0x6B175474E89094C44Da98b954EedeAC495271d0F);
 address constant MAKER_POT = address(0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7);
@@ -34,7 +34,7 @@ contract LSDAITestBase is Test, TestUtils {
    */
   function getMakerDaiSavingsRate() public returns (uint256) {
     bytes32 dsr = vm.load(address(MAKER_POT), bytes32(uint256(MAKER_POT_DSR_SLOT)));
-    emit log_named_uint('MakerDAO Dai Savings Rate', uint256(dsr));
+    emit log_named_uint("MakerDAO Dai Savings Rate", uint256(dsr));
 
     return uint256(dsr);
   }
@@ -57,15 +57,15 @@ contract LSDAITestBase is Test, TestUtils {
    * @dev Log LSDai metrics.
    */
   function logLSDAIMetrics(LSDai lsdai, string memory _header) public {
-    string memory header = bytes(_header).length > 0 ? string.concat(' ', _header, ' ') : '';
+    string memory header = bytes(_header).length > 0 ? string.concat(" ", _header, " ") : "";
 
-    emit log_string(string.concat('------- LSDai Metrics', header, '-------'));
-    emit log_named_decimal_uint('LSDAI total supply', lsdai.totalSupply(), 18);
-    emit log_named_decimal_uint('LSDAI protcol fees (fee feeRecipient)', lsdai.balanceOf(lsdai.feeRecipient()), 18);
-    emit log_named_decimal_uint('LSDAI total supply according to DSR', lsdai.getTotalPotSharesValue(), 18);
-    emit log_named_decimal_uint('LSDAI pot shares using pot.pie()', lsdai.potShares(), 18);
-    emit log_string('');
-    emit log_string('');
+    emit log_string(string.concat("------- LSDai Metrics", header, "-------"));
+    emit log_named_decimal_uint("LSDAI total supply", lsdai.totalSupply(), 18);
+    emit log_named_decimal_uint("LSDAI protcol fees (fee feeRecipient)", lsdai.balanceOf(lsdai.feeRecipient()), 18);
+    emit log_named_decimal_uint("LSDAI total supply according to DSR", lsdai.getTotalPotSharesValue(), 18);
+    emit log_named_decimal_uint("LSDAI pot shares using pot.pie()", lsdai.potShares(), 18);
+    emit log_string("");
+    emit log_string("");
   }
 
   /**
@@ -76,13 +76,13 @@ contract LSDAITestBase is Test, TestUtils {
     uint256 shares = lsdai.sharesOf(account);
 
     // Logging
-    emit log_string(string.concat('------- ', accountName, ' Metrics -------'));
-    emit log_named_decimal_uint(string.concat(accountName, ' LSDAI balance'), balance, 18);
-    emit log_named_decimal_uint(string.concat(accountName, ' LSDAI shares'), shares, 18);
+    emit log_string(string.concat("------- ", accountName, " Metrics -------"));
+    emit log_named_decimal_uint(string.concat(accountName, " LSDAI balance"), balance, 18);
+    emit log_named_decimal_uint(string.concat(accountName, " LSDAI shares"), shares, 18);
     // emit log_named_decimal_uint('balance shares', lsdai.getSharesByPooledDai(balance), 18);
-    emit log_named_decimal_uint(string.concat(accountName, ' DAI balance'), dai.balanceOf(account), 18);
+    emit log_named_decimal_uint(string.concat(accountName, " DAI balance"), dai.balanceOf(account), 18);
 
-    emit log_string('');
-    emit log_string('');
+    emit log_string("");
+    emit log_string("");
   }
 }


### PR DESCRIPTION
Address L1 from audit by making restricting `lsdai.rebase()` to addresses which have been granted the role `REBASER_ROLE`. Logic provided by OZ's AccessControl contract.

Notes: with AccessControl present, I think it's best to remove Ownable and transfer authorization to `DEFAULT_ADMIN_ROLE`.