### PR TITLE
chore: rewrite `_withdraw` sig (L2)

### DIFF
--- a/contracts/LSDai.sol
+++ b/contracts/LSDai.sol
@@ -217,14 +217,23 @@ contract LSDai is Ownable, ILSDai {
    * @param daiAmount The amount of LSDAI to withdraw. wad is denominated in dai
    */
   function withdraw(uint256 daiAmount) external returns (bool) {
-    return _withdraw(daiAmount, withdrawalFee);
+    return _withdraw(msg.sender, msg.sender, daiAmount, withdrawalFee);
+  }
+
+  /**
+   * Withdraw DAI from the contract to a specified address instead of the sender
+   * @param to The address to withdraw LSDAI to.
+   * @param daiAmount The amount of LSDAI to withdraw. wad is denominated in dai
+   */
+  function withdrawTo(address to, uint256 daiAmount) external returns (bool) {
+    return _withdraw(msg.sender, to, daiAmount, withdrawalFee);
   }
 
   /**
    * @dev withdraws the pending protocol fees from the DSR pot to the owner. Only callable by the owner.
    */
   function collectFees() external onlyOwner returns (bool) {
-    return _withdraw(balanceOf(feeRecipient), 0);
+    return _withdraw(feeRecipient, feeRecipient, balanceOf(feeRecipient), 0);
   }
 
   /**
@@ -392,11 +401,13 @@ contract LSDai is Ownable, ILSDai {
 
   /**
    * Withdraw shares back to DAI
+   * @param _from The address to withdraw LSDAI from.
+   * @param _to The address to withdraw DAI to.
    * @param _daiAmount The amount of LSDAI to withdraw. wad is denominated in (1/chi) * dai
    * @param _withdrawFee The fee to be charged on the withdrawal, in basis points.
    */
-  function _withdraw(uint256 _daiAmount, uint256 _withdrawFee) internal returns (bool) {
-    uint256 currentDaiBalance = balanceOf(msg.sender);
+  function _withdraw(address _from, address _to, uint256 _daiAmount, uint256 _withdrawFee) internal returns (bool) {
+    uint256 currentDaiBalance = balanceOf(_from);
     // Check if the user has enough LSDAI
     if (_daiAmount > currentDaiBalance) {
       revert LSDai__AmountExceedsBalance();
@@ -416,8 +427,8 @@ contract LSDai is Ownable, ILSDai {
     // Decrease the total amount of DAI pooled
     _totalPooledDai = _totalPooledDai.sub(withdrawAmount);
 
-    _transferShares(msg.sender, feeRecipient, feeShares);
-    _burnShares(msg.sender, withdrawShares);
+    _transferShares(_from, feeRecipient, feeShares);
+    _burnShares(_from, withdrawShares);
 
     // Withdraw from the DSR, roudning up ensures we get at least the amount of DAI requested
     uint256 withdrawPotShares = RMath.rdivup(withdrawAmount, chi);
@@ -425,16 +436,15 @@ contract LSDai is Ownable, ILSDai {
     _totalPotShares = _totalPotShares.sub(withdrawPotShares);
 
     // Burn LSDAI at 1:1 ratio to DAI
-    emit Transfer(msg.sender, address(0), withdrawAmount);
+    emit Transfer(_from, address(0), withdrawAmount);
 
     // Get back the DAI from the DSR to the contract
     pot.exit(withdrawPotShares);
 
-    //  daiJoin.exit(msg.sender, rmul(chi, wad)); // wad is in dai units
     daiJoin.exit(address(this), withdrawAmount); // wad is in dai units
 
     // Send it over
-    return dai.transfer(msg.sender, withdrawAmount);
+    return dai.transfer(_to, withdrawAmount);
   }
 
   /**

--- a/contracts/LSDai.sol
+++ b/contracts/LSDai.sol
@@ -230,7 +230,7 @@ contract LSDai is Ownable, ILSDai {
   }
 
   /**
-   * @dev withdraws the pending protocol fees from the DSR pot to the owner. Only callable by the owner.
+   * @dev withdraws the pending protocol fees from the DSR pot to the `feeRecipient`. Only callable by the owner.
    */
   function collectFees() external onlyOwner returns (bool) {
     return _withdraw(feeRecipient, feeRecipient, balanceOf(feeRecipient), 0);

--- a/test/LSDai.t.sol
+++ b/test/LSDai.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.20;
 
-import {SafeMath} from '@openzeppelin/contracts/utils/math/SafeMath.sol';
-import {Strings} from '@openzeppelin/contracts/utils/Strings.sol';
+import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
-import {LSDAITestBase, MAKER_POT} from './common/LSDAITestBase.sol';
-import {LSDai} from '../contracts/LSDai.sol';
-import {IDai} from '../contracts/interfaces/IDai.sol';
+import {LSDAITestBase, MAKER_POT} from "./common/LSDAITestBase.sol";
+import {LSDai} from "../contracts/LSDai.sol";
+import {IDai} from "../contracts/interfaces/IDai.sol";
 
 address constant DAI_ADDRESS = address(0x6B175474E89094C44Da98b954EedeAC495271d0F);
 
@@ -17,10 +17,7 @@ contract LSDaiTests is LSDAITestBase {
   event Transfer(address indexed from, address indexed to, uint256 value);
   event TransferShares(address indexed from, address indexed to, uint256 sharesValue);
   event SharesBurnt(
-    address indexed account,
-    uint256 preRebaseTokenAmount,
-    uint256 postRebaseTokenAmount,
-    uint256 sharesAmount
+    address indexed account, uint256 preRebaseTokenAmount, uint256 postRebaseTokenAmount, uint256 sharesAmount
   );
 
   LSDai lsdai;
@@ -61,8 +58,8 @@ contract LSDaiTests is LSDAITestBase {
 
   function test_lsdaiIsERC20ish() public {
     // Check if the contract implements the ERC20 interface
-    assertEq(lsdai.symbol(), 'LSDAI');
-    assertEq(lsdai.name(), 'Liquid Savings DAI');
+    assertEq(lsdai.symbol(), "LSDAI");
+    assertEq(lsdai.name(), "Liquid Savings DAI");
     assertEq(lsdai.decimals(), 18);
 
     // Deposit DAI from LSD tripper
@@ -91,8 +88,7 @@ contract LSDaiTests is LSDAITestBase {
       // Check LSD Tripper balance
       assertEq(lsdai.balanceOf(lsdTripper), lsdaiTripperBalanceBeforeTransfer - balanceToTransfer);
       assertEq(
-        lsdai.sharesOf(lsdTripper),
-        lsdai.getSharesByPooledDai(lsdaiTripperBalanceBeforeTransfer - balanceToTransfer)
+        lsdai.sharesOf(lsdTripper), lsdai.getSharesByPooledDai(lsdaiTripperBalanceBeforeTransfer - balanceToTransfer)
       );
       // Check LSD Enjoyer balance
       assertEq(lsdai.balanceOf(lsdEnjoyer), balanceToTransfer);
@@ -126,9 +122,8 @@ contract LSDaiTests is LSDAITestBase {
 
     uint256 expectedTotalLSDaiSharesAfterBurn = lsdai.totalShares() - expectedSharesToBurn;
 
-    uint256 expectedPostRebaseTokenAmount = expectedSharesToBurn.mul(expectedTotalLSDaiSharesAfterBurn).div(
-      expectedTotalLSDaiSharesAfterBurn
-    );
+    uint256 expectedPostRebaseTokenAmount =
+      expectedSharesToBurn.mul(expectedTotalLSDaiSharesAfterBurn).div(expectedTotalLSDaiSharesAfterBurn);
 
     // Submit withdrawal request
     vm.prank(lsdTripper);
@@ -155,14 +150,14 @@ contract LSDaiTests is LSDAITestBase {
     assert(dai.balanceOf(lsdTripper) == 0);
     assert(lsdai.balanceOf(lsdTripper) == lsdTripperInitialDeposit); // since 1:1 ratio and we're in the same block
 
-    logLSDAIMetrics(lsdai, 'at week 1');
+    logLSDAIMetrics(lsdai, "at week 1");
 
     vm.warp(block.timestamp + 52 weeks);
 
     lsdai.rebase();
-    logLSDAIMetrics(lsdai, 'at week 52');
+    logLSDAIMetrics(lsdai, "at week 52");
 
-    logLSDaiUserMetrics(lsdai, lsdTripper, 'LSD Tripper');
+    logLSDaiUserMetrics(lsdai, lsdTripper, "LSD Tripper");
     // Withdraw DAI from LSD tripper
     withdrawDAI(lsdTripper, lsdai.balanceOf(lsdTripper));
   }
@@ -173,13 +168,13 @@ contract LSDaiTests is LSDAITestBase {
     depositDAI(lsdEnjoyer, lsdEnjoyerInitialDeposit);
     depositDAI(lsdDreamer, lsdDreamerInitialDeposit);
 
-    logLSDAIMetrics(lsdai, 'at week 1');
+    logLSDAIMetrics(lsdai, "at week 1");
 
     // Warp to 52 weeks
     vm.warp(block.timestamp + 52 weeks);
     lsdai.rebase();
 
-    logLSDAIMetrics(lsdai, 'at week 52');
+    logLSDAIMetrics(lsdai, "at week 52");
 
     // Withdraw from LSD tripper
     {
@@ -199,30 +194,30 @@ contract LSDaiTests is LSDAITestBase {
       assertTrue(
         lsdaiEnjoyerBalanceAfterWithdraw >= lsdaiEnjoyerBalanceBeforeWithdraw,
         string.concat(
-          'LSD Enjoyer should have same or more LSDai after LSD tripper withdraws. ',
-          'Expected: ',
+          "LSD Enjoyer should have same or more LSDai after LSD tripper withdraws. ",
+          "Expected: ",
           Strings.toString(lsdaiEnjoyerBalanceBeforeWithdraw),
-          ' or more. Got:',
+          " or more. Got:",
           Strings.toString(lsdaiEnjoyerBalanceAfterWithdraw)
         )
       );
       assertTrue(
         lsdaiDreamerBalanceAfterWithdraw >= lsdaiDreamerBalanceBeforeWithdraw,
         string.concat(
-          'LSD Dreamer should have same or more LSDai after LSD tripper withdraws. ',
-          'Expected: ',
+          "LSD Dreamer should have same or more LSDai after LSD tripper withdraws. ",
+          "Expected: ",
           Strings.toString(lsdaiDreamerBalanceBeforeWithdraw),
-          ' or more. Got:',
+          " or more. Got:",
           Strings.toString(lsdaiDreamerBalanceAfterWithdraw)
         )
       );
       assertTrue(
         feeRecipientBalanceAfterWithdraw >= feeRecipientBalanceBeforeWithdraw,
         string.concat(
-          'LSDai Fee Recipient should have same or more LSDai after LSD tripper withdraws. ',
-          'Expected: ',
+          "LSDai Fee Recipient should have same or more LSDai after LSD tripper withdraws. ",
+          "Expected: ",
           Strings.toString(feeRecipientBalanceBeforeWithdraw),
-          ' or more. Got:',
+          " or more. Got:",
           Strings.toString(feeRecipientBalanceAfterWithdraw)
         )
       );
@@ -244,20 +239,20 @@ contract LSDaiTests is LSDAITestBase {
       assertTrue(
         lsdaiDreamerBalanceAfterWithdraw >= lsdaiDreamerBalanceBeforeWithdraw,
         string.concat(
-          'LSD Dreamer should have same or more LSDai after LSD Enjoyer withdraws. ',
-          'Expected: ',
+          "LSD Dreamer should have same or more LSDai after LSD Enjoyer withdraws. ",
+          "Expected: ",
           Strings.toString(lsdaiDreamerBalanceBeforeWithdraw),
-          ' or more. Got:',
+          " or more. Got:",
           Strings.toString(lsdaiDreamerBalanceAfterWithdraw)
         )
       );
       assertTrue(
         feeRecipientBalanceAfterWithdraw >= feeRecipientBalanceBeforeWithdraw,
         string.concat(
-          'LSDai Fee Recipient should have same or more LSDai after LSD Enjoyer withdraws. ',
-          'Expected: ',
+          "LSDai Fee Recipient should have same or more LSDai after LSD Enjoyer withdraws. ",
+          "Expected: ",
           Strings.toString(feeRecipientBalanceBeforeWithdraw),
-          ' or more. Got:',
+          " or more. Got:",
           Strings.toString(feeRecipientBalanceAfterWithdraw)
         )
       );
@@ -273,16 +268,16 @@ contract LSDaiTests is LSDAITestBase {
 
       assertTrue(
         lsdai.balanceOf(lsdai.feeRecipient()) >= feeRecipientBalanceBeforeWithdraw,
-        'LSDai Fee Recipient should have same or more LSDai after LSD Dreamer withdraws'
+        "LSDai Fee Recipient should have same or more LSDai after LSD Dreamer withdraws"
       );
     }
 
-    logLSDAIMetrics(lsdai, 'after everyone withdrew');
+    logLSDAIMetrics(lsdai, "after everyone withdrew");
   }
 
   function test_UserCannotExceedTheirBalanceOnWithdrawal() public {
     depositDAI(lsdTripper, lsdTripperInitialDeposit);
-    assertEq(lsdai.balanceOf(lsdTripper), lsdTripperInitialDeposit, 'LSD tripper should have initial deposit');
+    assertEq(lsdai.balanceOf(lsdTripper), lsdTripperInitialDeposit, "LSD tripper should have initial deposit");
     uint256 attemptToWithdrawByHacker = lsdai.balanceOf(lsdTripper) - 10 ether;
     vm.startPrank(lsdEnjoyer);
     vm.expectRevert(LSDai.LSDai__AmountExceedsBalance.selector);
@@ -293,9 +288,9 @@ contract LSDaiTests is LSDAITestBase {
     uint256 initialDeposit = dai.balanceOf(lsdTripper);
     // Deposit everything into LSDai
     depositDAI(lsdTripper, initialDeposit);
-    assertEq(dai.balanceOf(lsdTripper), 0, 'LSD tripper should have 0 DAI');
+    assertEq(dai.balanceOf(lsdTripper), 0, "LSD tripper should have 0 DAI");
     // 1:1 ratio
-    assertEq(lsdai.balanceOf(lsdTripper), initialDeposit, 'LSD tripper should have initial deposit');
+    assertEq(lsdai.balanceOf(lsdTripper), initialDeposit, "LSD tripper should have initial deposit");
 
     vm.warp(block.timestamp + 52 weeks);
     lsdai.rebase();
@@ -304,18 +299,18 @@ contract LSDaiTests is LSDAITestBase {
     vm.startPrank(lsdTripper);
     lsdai.withdraw(daiAmountToWithdraw);
 
-    emit log_named_uint('DAI balance', dai.balanceOf(lsdTripper));
-    emit log_named_uint('LSDai balance', lsdai.balanceOf(lsdTripper));
+    emit log_named_uint("DAI balance", dai.balanceOf(lsdTripper));
+    emit log_named_uint("LSDai balance", lsdai.balanceOf(lsdTripper));
   }
 
   function test_UserCanWithdrawRecievedLSDAI() public {
     uint256 initialDeposit = dai.balanceOf(lsdTripper);
     // Deposit everything into LSDai
     depositDAI(lsdTripper, initialDeposit);
-    assertEq(dai.balanceOf(lsdTripper), 0, 'LSD tripper should have 0 DAI');
+    assertEq(dai.balanceOf(lsdTripper), 0, "LSD tripper should have 0 DAI");
     // 1:1 ratio
-    assertEq(lsdai.balanceOf(lsdTripper), initialDeposit, 'LSD tripper should have initial deposit');
-    assertEq(lsdai.balanceOf(lsdEnjoyer), 0, 'LSD Enjoyer should have 0 LSDai');
+    assertEq(lsdai.balanceOf(lsdTripper), initialDeposit, "LSD tripper should have initial deposit");
+    assertEq(lsdai.balanceOf(lsdEnjoyer), 0, "LSD Enjoyer should have 0 LSDai");
 
     vm.warp(block.timestamp + 52 weeks);
     lsdai.rebase();
@@ -333,7 +328,7 @@ contract LSDaiTests is LSDAITestBase {
   function test_depositCapEnforced() public {
     // Set deposit cap to 100 DAI
     lsdai.setDepositCap(100 ether);
-    assertEq(lsdai.depositCap(), 100 ether, 'Deposit cap should be 100 DAI');
+    assertEq(lsdai.depositCap(), 100 ether, "Deposit cap should be 100 DAI");
 
     uint256 currentDepositCap = lsdai.depositCap();
     // Use the entire deposit cap by depositing the max amount
@@ -358,40 +353,69 @@ contract LSDaiTests is LSDAITestBase {
   }
 
   function test_feeRecipient() public {
-    assertEq(lsdai.feeRecipient(), address(this), 'Fee recipient should be this contract');
+    assertEq(lsdai.feeRecipient(), address(this), "Fee recipient should be this contract");
     // Set fee recipient to lsdTripper
     lsdai.setFeeRecipient(lsdTripper);
-    assertEq(lsdai.feeRecipient(), lsdTripper, 'Fee recipient should be lsdTripper');
+    assertEq(lsdai.feeRecipient(), lsdTripper, "Fee recipient should be lsdTripper");
     // Set fee recipient to lsdEnjoyer
     lsdai.setFeeRecipient(lsdEnjoyer);
-    assertEq(lsdai.feeRecipient(), lsdEnjoyer, 'Fee recipient should be lsdEnjoyer');
+    assertEq(lsdai.feeRecipient(), lsdEnjoyer, "Fee recipient should be lsdEnjoyer");
     // Set fee recipient to lsdDreamer
     lsdai.setFeeRecipient(lsdDreamer);
-    assertEq(lsdai.feeRecipient(), lsdDreamer, 'Fee recipient should be lsdDreamer');
+    assertEq(lsdai.feeRecipient(), lsdDreamer, "Fee recipient should be lsdDreamer");
   }
 
   function test_setWithdrawalFee() public {
     // Set withdrawal fee to 1%
     lsdai.setWithdrawalFee(100);
-    assertEq(lsdai.withdrawalFee(), 100, 'Withdrawal fee should be 1%');
+    assertEq(lsdai.withdrawalFee(), 100, "Withdrawal fee should be 1%");
     // Set withdrawal fee to 2%
     lsdai.setWithdrawalFee(200);
-    assertEq(lsdai.withdrawalFee(), 200, 'Withdrawal fee should be 2%');
+    assertEq(lsdai.withdrawalFee(), 200, "Withdrawal fee should be 2%");
     // Set withdrawal fee to 3%
     lsdai.setWithdrawalFee(300);
-    assertEq(lsdai.withdrawalFee(), 300, 'Withdrawal fee should be 3%');
+    assertEq(lsdai.withdrawalFee(), 300, "Withdrawal fee should be 3%");
   }
 
   function test_setInterestFee() public {
     // Set interest fee to 1%
     lsdai.setInterestFee(100);
-    assertEq(lsdai.interestFee(), 100, 'Interest fee should be 1%');
+    assertEq(lsdai.interestFee(), 100, "Interest fee should be 1%");
     // Set interest fee to 2%
     lsdai.setInterestFee(200);
-    assertEq(lsdai.interestFee(), 200, 'Interest fee should be 2%');
+    assertEq(lsdai.interestFee(), 200, "Interest fee should be 2%");
     // Set interest fee to 3%
     lsdai.setInterestFee(300);
-    assertEq(lsdai.interestFee(), 300, 'Interest fee should be 3%');
+    assertEq(lsdai.interestFee(), 300, "Interest fee should be 3%");
+  }
+
+  function test_collectFees() public {
+    address prevFeeRecipient = lsdai.feeRecipient();
+    address feeRecipient = address(0x123);
+
+    // Set fee recipient to feeRecipient
+    assertEq(dai.balanceOf(prevFeeRecipient), 0, "Fee recipient should have 0 DAI");
+    assertEq(dai.balanceOf(feeRecipient), 0, "Fee recipient should have 0 DAI");
+
+    // Update fee recipient
+    lsdai.setFeeRecipient(feeRecipient);
+
+    assertEq(lsdai.feeRecipient(), feeRecipient, "Fee recipient should be feeRecipient");
+
+    // deposit for lsdTripper
+    depositDAI(lsdTripper, lsdTripperInitialDeposit);
+
+    // Warp and rebase
+    vm.warp(block.timestamp + 52 weeks);
+    vm.prank(lsdai.owner()); // owner can rebase
+    lsdai.rebase();
+
+    // Expected DAI balance of fee recipient after collecting fees
+    uint256 expectedDAIBalance = lsdai.balanceOf(feeRecipient);
+
+    lsdai.collectFees();
+
+    assertApproxEqAbs(dai.balanceOf(feeRecipient), expectedDAIBalance, 1 ether);
   }
 
   function depositDAI(address account, uint256 daiAmount) public {


### PR DESCRIPTION
To fix L2, a rewrite of `_withdraw` is required such that it accepts a parameter `address _from` to process withdrawal for desired address.