### PR TITLE
chore: implement sanity checks on interest and withdrawal fees (L3 and L5)

### DIFF
--- a/contracts/LSDai.sol
+++ b/contracts/LSDai.sol
@@ -24,8 +24,8 @@ contract LSDai is Ownable, ILSDai {
   error LSDai__AlreadyInitialized();
   error LSDai__DepositCapLowerThanTotalPooledDai();
   error LSDai__DepositCap();
-  error LSDai__WithdrawalFeeLow();
-  error LSDai__InterestFeeLow();
+  error LSDai__WithdrawalFeeHigh();
+  error LSDai__InterestFeeHigh();
   error LSDai__TransferToZeroAddress();
   error LSDai__TransferFromZeroAddress();
   error LSDai__TransferToLSDaiContract();
@@ -228,12 +228,13 @@ contract LSDai is Ownable, ILSDai {
   }
 
   /**
-   * @dev Updates the withdrawal fee. Only callable by the owner.
+   * @dev Updates the withdrawal fee, possible values between 0 and . Only callable by the owner.
    * @param fee The new withdrawal fee, in basis points.
    */
   function setWithdrawalFee(uint256 fee) public onlyOwner {
-    if (fee < 0) {
-      revert LSDai__WithdrawalFeeLow();
+    // Cap at 0.05% (5 basis points)
+    if (fee > 5) {
+      revert LSDai__WithdrawalFeeHigh();
     }
 
     withdrawalFee = fee;
@@ -246,8 +247,9 @@ contract LSDai is Ownable, ILSDai {
    * @param fee The new interest fee, in basis points.
    */
   function setInterestFee(uint256 fee) public onlyOwner {
-    if (fee < 0) {
-      revert LSDai__InterestFeeLow();
+    // Cap at 5% (500 basis points)
+    if (fee > 500) {
+      revert LSDai__InterestFeeHigh();
     }
 
     interestFee = fee;

--- a/test/LSDai.t.sol
+++ b/test/LSDai.t.sol
@@ -371,27 +371,24 @@ contract LSDaiTests is LSDAITestBase {
   }
 
   function test_setWithdrawalFee() public {
-    // Set withdrawal fee to 1%
-    lsdai.setWithdrawalFee(100);
-    assertEq(lsdai.withdrawalFee(), 100, 'Withdrawal fee should be 1%');
-    // Set withdrawal fee to 2%
-    lsdai.setWithdrawalFee(200);
-    assertEq(lsdai.withdrawalFee(), 200, 'Withdrawal fee should be 2%');
-    // Set withdrawal fee to 3%
-    lsdai.setWithdrawalFee(300);
-    assertEq(lsdai.withdrawalFee(), 300, 'Withdrawal fee should be 3%');
+    // Set withdrawal fee to 0.03%
+    lsdai.setWithdrawalFee(3);
+    assertEq(lsdai.withdrawalFee(), 3, 'Withdrawal fee should be 0.03%');
+    // Revert if the fee is greater than 0.05%
+    vm.expectRevert(LSDai.LSDai__WithdrawalFeeHigh.selector);
+    lsdai.setWithdrawalFee(6);
   }
 
   function test_setInterestFee() public {
     // Set interest fee to 1%
     lsdai.setInterestFee(100);
     assertEq(lsdai.interestFee(), 100, 'Interest fee should be 1%');
-    // Set interest fee to 2%
-    lsdai.setInterestFee(200);
-    assertEq(lsdai.interestFee(), 200, 'Interest fee should be 2%');
     // Set interest fee to 3%
     lsdai.setInterestFee(300);
     assertEq(lsdai.interestFee(), 300, 'Interest fee should be 3%');
+    // Revert on interest fee greater than 5%
+    vm.expectRevert(LSDai.LSDai__InterestFeeHigh.selector);
+    lsdai.setInterestFee(501);
   }
 
   function depositDAI(address account, uint256 daiAmount) public {


### PR DESCRIPTION
From the audit:

L3

> L3. Implement sanity checks on fee and interestFee [low]
In setWithdrawalFee(), no restrictions are put on the new value for the fee. This means that the owner of the contract can set the fee at 100% (effectively taking the entire deposit of the user) or to a value higher than 100% (which will block withdrawals from users entirely, as these will revert). 
Similar considerations hold for interestFee, although with less dire consequences.
Recommendation: Enforce limits on the values for withdrawalFee and interestFee.
Severity: Low

L5

> L5. remove unnecessary checks [low]
On line 235, and again on line 249:
> ```
>  if (fee < 0) {
> ```
> These checks are not necessary as fee is of the type uint, and so it can only be 0 or more.
Recommendation: Remove these needless checks on lines 235 and 249 to save some gas.
Severity: Low