### PR TITLE
chore: remove unenforceable check for the cap (L6)

### DIFF
--- a/contracts/LSDai.sol
+++ b/contracts/LSDai.sol
@@ -22,7 +22,6 @@ import {IVat} from "./interfaces/IVat.sol";
  */
 contract LSDai is Ownable, ILSDai {
   error LSDai__AlreadyInitialized();
-  error LSDai__DepositCapLowerThanTotalPooledDai();
   error LSDai__DepositCap();
   error LSDai__WithdrawalFeeHigh();
   error LSDai__InterestFeeHigh();
@@ -341,11 +340,6 @@ contract LSDai is Ownable, ILSDai {
    * @notice Sets deposit cap. Exclusive for the owner.
    */
   function setDepositCap(uint256 cap) public onlyOwner {
-    // Must be higher than total pooled DAI
-    if (cap < _getTotalPooledDai()) {
-      revert LSDai__DepositCapLowerThanTotalPooledDai();
-    }
-
     depositCap = cap;
 
     emit DepositCapSet(cap);

--- a/test/LSDai.t.sol
+++ b/test/LSDai.t.sol
@@ -340,16 +340,6 @@ contract LSDaiTests is LSDAITestBase {
     vm.prank(lsdTripper);
     vm.expectRevert(LSDai.LSDai__DepositCap.selector);
     lsdai.deposit({daiAmount: depositAmount, to: lsdTripper});
-
-    // Ensure that deposit cap cannot be lowered below the current pooled DAI
-    vm.warp(block.timestamp + 1 weeks);
-    lsdai.rebase();
-    uint256 currentPooledDai = lsdai.totalSupply();
-    // Withdraw 1 DAI to make room for the next deposit
-    uint256 nextDepositCap = currentPooledDai - 1;
-    // Next deposit cannot exceed current pooled DAI
-    vm.expectRevert(LSDai.LSDai__DepositCapLowerThanTotalPooledDai.selector);
-    lsdai.setDepositCap(nextDepositCap);
   }
 
   function test_feeRecipient() public {


### PR DESCRIPTION
From audit: 

> L6. Remove unenforceable check for the cap [low]
On line 33, in setDepositCap, it is checked whether the new cap value does not exceed the current DAI balance in the contract:
> ```solidity
> if (cap < _getTotalPooledDai()) {
> ```
> This condition does not guarantee that the  total amount of DAI in the pool is less than the depositCap, as the amount of DAI may grow on rebase when collecting interest.
> In any case, it seems harmless for the depositCap being lower than the total amount of DAI in the contract, and there is a viable use case for setting the depositCap lower than that (for example, you could set the depositCap to a very low value if you for some reason want to disallow any new deposits and only allow withdrawals)
Recommendation: Remove this check.
Severity: Low