### PR TITLE
chore: remove default values in proxy implementation (L7)

### DIFF
--- a/contracts/LSDai.sol
+++ b/contracts/LSDai.sol
@@ -103,12 +103,12 @@ contract LSDai is Ownable, ILSDai {
   /**
    * @notice Interest fee taken on interest earned, in basis points.
    */
-  uint256 public interestFee = 250; // 2.5%
+  uint256 public interestFee;
 
   /**
    * @notice Withdrawal fee taken on exit, in basis points.
    */
-  uint256 public withdrawalFee = 1; // 0.01%
+  uint256 public withdrawalFee;
 
   /**
    * @notice Fee recipient address.


### PR DESCRIPTION
> L7. Remove default values in proxy implementation [info]
The contract defines values for interestFee and withdrawalFee. Because these values are stored in the implementation contract, they cannot be read by the proxy contract - the values that the proxy contract will use are those set by the initialize function. 
> ```solidity
> uint256 public interestFee = 250; // 2.5% 
> uint256 public withdrawalFee = 1; // 0.01%
> ```
> Recommendation: Remove these default values  to avoid confusion (and save a minimal amount of gas on deployment).
Severity: Info