### PR TITLE
chore: `potShares()` can be defined as external (L8)

### DIFF
--- a/contracts/LSDai.sol
+++ b/contracts/LSDai.sol
@@ -172,7 +172,7 @@ contract LSDai is Ownable, ILSDai {
   /**
    * @dev returns the amount of pot shares the LSDAI contract has in the DSR pot contract
    */
-  function potShares() public view returns (uint256) {
+  function potShares() external view returns (uint256) {
     return pot.pie(address(this));
   }
 


### PR DESCRIPTION
> L8. `potShares()` can be defined external [info]
The `potShares()` function is not called from anywhere else in the contract and can be declared external.
Recommendation: Mark the function external.
Severity: Info