### PR TITLE
chore(fees): increase `withdrawalFee` cap to 0.2%

### DIFF
--- a/contracts/LSDai.sol
+++ b/contracts/LSDai.sol
@@ -236,12 +236,11 @@ contract LSDai is Ownable, ILSDai {
   }
 
   /**
-   * @dev Updates the withdrawal fee, possible values between 0 and 1%. Only callable by the owner.
+   * @dev Updates the withdrawal fee, possible values between 0 and 0.2%. Only callable by the owner.
    * @param fee The new withdrawal fee, in basis points.
    */
   function setWithdrawalFee(uint256 fee) public onlyOwner {
-    // Cap at 1% (100 basis points)
-    if (fee > 100) {
+    if (fee > 20) {
       revert LSDai__WithdrawalFeeHigh();
     }
 

--- a/contracts/LSDai.sol
+++ b/contracts/LSDai.sol
@@ -236,12 +236,12 @@ contract LSDai is Ownable, ILSDai {
   }
 
   /**
-   * @dev Updates the withdrawal fee, possible values between 0 and . Only callable by the owner.
+   * @dev Updates the withdrawal fee, possible values between 0 and 1%. Only callable by the owner.
    * @param fee The new withdrawal fee, in basis points.
    */
   function setWithdrawalFee(uint256 fee) public onlyOwner {
-    // Cap at 0.05% (5 basis points)
-    if (fee > 5) {
+    // Cap at 1% (100 basis points)
+    if (fee > 100) {
       revert LSDai__WithdrawalFeeHigh();
     }
 

--- a/test/LSDai.t.sol
+++ b/test/LSDai.t.sol
@@ -359,9 +359,9 @@ contract LSDaiTests is LSDAITestBase {
     // Set withdrawal fee to 0.03%
     lsdai.setWithdrawalFee(3);
     assertEq(lsdai.withdrawalFee(), 3, 'Withdrawal fee should be 0.03%');
-    // Revert if the fee is greater than 0.05%
+    // Revert if the fee is greater than 1%
     vm.expectRevert(LSDai.LSDai__WithdrawalFeeHigh.selector);
-    lsdai.setWithdrawalFee(6);
+    lsdai.setWithdrawalFee(101); // 1.01%
   }
 
   function test_setInterestFee() public {

--- a/test/LSDai.t.sol
+++ b/test/LSDai.t.sol
@@ -361,7 +361,7 @@ contract LSDaiTests is LSDAITestBase {
     assertEq(lsdai.withdrawalFee(), 3, 'Withdrawal fee should be 0.03%');
     // Revert if the fee is greater than 1%
     vm.expectRevert(LSDai.LSDai__WithdrawalFeeHigh.selector);
-    lsdai.setWithdrawalFee(101); // 1.01%
+    lsdai.setWithdrawalFee(21); // 0.21%
   }
 
   function test_setInterestFee() public {


### PR DESCRIPTION
Sets the upper bound for withdrawalFee to 0.2%